### PR TITLE
feat: [이재림] Auth 로그인 URL 요청 및 외부 인증 페이지 이동 로직 구현 [ETH-18]

### DIFF
--- a/src/domains/authentication/login/application/commands/loginCommands.ts
+++ b/src/domains/authentication/login/application/commands/loginCommands.ts
@@ -1,9 +1,26 @@
 import type { AuthProvider } from '../../domain/model/AuthProvider';
+import { authApi } from '../../infrastructure/api/authApi'
 
-export type LoginCommand = () => void;
+export type LoginCommand = () => Promise<void>;
+
+async function socialLogin(provider: AuthProvider) {
+    try {
+        const loginUrl = await authApi.getLoginUrl(provider);
+
+        console.log('loginUrl:', loginUrl);
+
+        if (!loginUrl) {
+            throw new Error('로그인 URL 없음');
+        }
+
+        window.location.href = loginUrl;
+    } catch (e) {
+        console.error('에러 발생:', e);
+    }
+}
 
 export const loginCommands: Record<AuthProvider, LoginCommand> = {
-    GOOGLE: () => alert('구글 계정 로그인 페이지 이동'),
-    KAKAO: () => alert('카카오 계정 로그인 페이지 이동'),
-    NAVER: () => alert('네이버 계정 로그인 페이지 이동')
+    GOOGLE: () => socialLogin('GOOGLE'),
+    KAKAO: () => socialLogin('KAKAO'),
+    NAVER: () => socialLogin('NAVER')
 };

--- a/src/domains/authentication/login/infrastructure/api/authApi.ts
+++ b/src/domains/authentication/login/infrastructure/api/authApi.ts
@@ -1,0 +1,28 @@
+import { axiosInstance } from '../../../../../api/axiosInstance'
+import type { AuthProvider } from '../../domain/model/AuthProvider'
+
+export const authApi = {
+    // 로그인 URL 요청
+    async getLoginUrl(provider: AuthProvider): Promise<string> {
+        const response = await axiosInstance.spring.post('/oauth/link', {
+            provider // "KAKAO"
+        })
+        console.log('API 응답:', response);
+
+        const url = response.data?.oauthUrl;
+
+        return url;
+    },
+
+    // redirect 이후 로그인 처리
+    async loginWithCode(provider: AuthProvider, code: string) {
+        const response = await axiosInstance.spring.get(
+            '/oauth/request-access-token-after-redirection',
+            {
+                params: { code }
+            }
+        );
+
+        return response.data;
+    }
+}

--- a/src/domains/authentication/login/infrastructure/storage/tokenStorage.ts
+++ b/src/domains/authentication/login/infrastructure/storage/tokenStorage.ts
@@ -1,0 +1,15 @@
+const TOKEN_KEY = 'userToken';
+
+export const tokenStorage = {
+    saveToken(token: string) {
+        localStorage.setItem(TOKEN_KEY, token);
+    },
+
+    getToken() {
+        return localStorage.getItem(TOKEN_KEY);
+    },
+
+    removeToken() {
+        localStorage.removeItem(TOKEN_KEY);
+    },
+};

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,7 +1,7 @@
 const env = {
     mode: import.meta.env.MODE,
     api: {
-        MAIN_API_URL: import.meta.env.VITE_MAIN_API_URL || 'http://localhost:8080',
+        MAIN_API_URL: import.meta.env.VITE_MAIN_API_URL || 'http://localhost:7777',
 
         kakao: import.meta.env.VITE_KAKAO_AUTH_URL,
         google: import.meta.env.VITE_GOOGLE_AUTH_URL,


### PR DESCRIPTION
- authApi를 통한 로그인 URL 요청 API 연동
- provider 기반 login command 구조 구현
- 로그인 URL 응답 후 외부 인증 페이지로 redirect 처리
- tokenStorage 추가 (accessToken 저장/조회/삭제)
- env 기반 API URL 설정 수정